### PR TITLE
Feature: implement edit-tag transactions

### DIFF
--- a/libgreader/auth.py
+++ b/libgreader/auth.py
@@ -51,7 +51,7 @@ class AuthenticationMethod(object):
 
     def postParameters(self, post=None):
         if post is not None:
-            post_string = urllib.urlencode(post)
+            post_string = urllib.urlencode(post, True)
         else:
             post_string = None
         return post_string


### PR DESCRIPTION
Google Reader API allows to batch edit-tag actions into single call.
I've implemented it since it greatly reduces the number (O(n) vs. O(n*m)) of urlfetch calls billed at GAE.

TODO: what if in commit an edit-tag call fails?
