### PR TITLE
Feature: Add since/until options to get feeds

### DIFF
--- a/libgreader/googlereader.py
+++ b/libgreader/googlereader.py
@@ -133,7 +133,7 @@ class GoogleReader(object):
 
         return True
 
-    def _getFeedContent(self, url, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
+    def _getFeedContent(self, url, excludeRead=False, continuation=None, loadLimit=20, since=None, until=None):
         """
         A list of items (from a feed, a category or from URLs made with SPECIAL_ITEMS_URL)
 
@@ -154,10 +154,10 @@ class GoogleReader(object):
         if continuation:
             parameters['c'] = continuation
         parameters['n'] = loadLimit
-        if publishedSince:
-            parameters['ot'] = publishedSince
-        if publishedUntil:
-            parameters['nt'] = publishedUntil
+        if since:
+            parameters['ot'] = since
+        if until:
+            parameters['nt'] = until
         contentJson = self.httpGet(url, parameters)
         return json.loads(contentJson, strict=False)
 
@@ -167,17 +167,17 @@ class GoogleReader(object):
             objects.append(Item(self, item, parent))
         return objects
 
-    def getFeedContent(self, feed, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
+    def getFeedContent(self, feed, excludeRead=False, continuation=None, loadLimit=20, since=None, until=None):
         """
         Return items for a particular feed
         """
-        return self._getFeedContent(feed.fetchUrl, excludeRead, continuation, loadLimit, publishedSince, publishedUntil)
+        return self._getFeedContent(feed.fetchUrl, excludeRead, continuation, loadLimit, since, until)
 
-    def getCategoryContent(self, category, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
+    def getCategoryContent(self, category, excludeRead=False, continuation=None, loadLimit=20, since=None, until=None):
         """
         Return items for a particular category
         """
-        return self._getFeedContent(category.fetchUrl, excludeRead, continuation, loadLimit, publishedSince, publishedUntil)
+        return self._getFeedContent(category.fetchUrl, excludeRead, continuation, loadLimit, since, until)
 
     def _modifyItemTag(self, item_id, action, tag):
         """ wrapper around actual HTTP POST string for modify tags """

--- a/libgreader/googlereader.py
+++ b/libgreader/googlereader.py
@@ -158,8 +158,6 @@ class GoogleReader(object):
             parameters['ot'] = updatedSince
         if updatedUntil:
             parameters['nt'] = updatedUntil
-        print parameters
-        print url
         contentJson = self.httpGet(url, parameters)
         return json.loads(contentJson, strict=False)
 

--- a/libgreader/googlereader.py
+++ b/libgreader/googlereader.py
@@ -133,7 +133,7 @@ class GoogleReader(object):
 
         return True
 
-    def _getFeedContent(self, url, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
+    def _getFeedContent(self, url, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
         """
         A list of items (from a feed, a category or from URLs made with SPECIAL_ITEMS_URL)
 
@@ -154,10 +154,10 @@ class GoogleReader(object):
         if continuation:
             parameters['c'] = continuation
         parameters['n'] = loadLimit
-        if updatedSince:
-            parameters['ot'] = updatedSince
-        if updatedUntil:
-            parameters['nt'] = updatedUntil
+        if publishedSince:
+            parameters['ot'] = publishedSince
+        if publishedUntil:
+            parameters['nt'] = publishedUntil
         contentJson = self.httpGet(url, parameters)
         return json.loads(contentJson, strict=False)
 
@@ -167,17 +167,17 @@ class GoogleReader(object):
             objects.append(Item(self, item, parent))
         return objects
 
-    def getFeedContent(self, feed, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
+    def getFeedContent(self, feed, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
         """
         Return items for a particular feed
         """
-        return self._getFeedContent(feed.fetchUrl, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
+        return self._getFeedContent(feed.fetchUrl, excludeRead, continuation, loadLimit, publishedSince, publishedUntil)
 
-    def getCategoryContent(self, category, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
+    def getCategoryContent(self, category, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
         """
         Return items for a particular category
         """
-        return self._getFeedContent(category.fetchUrl, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
+        return self._getFeedContent(category.fetchUrl, excludeRead, continuation, loadLimit, publishedSince, publishedUntil)
 
     def _modifyItemTag(self, item_id, action, tag):
         """ wrapper around actual HTTP POST string for modify tags """

--- a/libgreader/googlereader.py
+++ b/libgreader/googlereader.py
@@ -133,7 +133,7 @@ class GoogleReader(object):
 
         return True
 
-    def _getFeedContent(self, url, excludeRead=False, continuation=None, loadLimit=20):
+    def _getFeedContent(self, url, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
         """
         A list of items (from a feed, a category or from URLs made with SPECIAL_ITEMS_URL)
 
@@ -154,6 +154,12 @@ class GoogleReader(object):
         if continuation:
             parameters['c'] = continuation
         parameters['n'] = loadLimit
+        if updatedSince:
+            parameters['ot'] = updatedSince
+        if updatedUntil:
+            parameters['nt'] = updatedUntil
+        print parameters
+        print url
         contentJson = self.httpGet(url, parameters)
         return json.loads(contentJson, strict=False)
 
@@ -163,17 +169,17 @@ class GoogleReader(object):
             objects.append(Item(self, item, parent))
         return objects
 
-    def getFeedContent(self, feed, excludeRead=False, continuation=None, loadLimit=20):
+    def getFeedContent(self, feed, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
         """
         Return items for a particular feed
         """
-        return self._getFeedContent(feed.fetchUrl, excludeRead, continuation, loadLimit)
+        return self._getFeedContent(feed.fetchUrl, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
 
-    def getCategoryContent(self, category, excludeRead=False, continuation=None, loadLimit=20):
+    def getCategoryContent(self, category, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
         """
         Return items for a particular category
         """
-        return self._getFeedContent(category.fetchUrl, excludeRead, continuation, loadLimit)
+        return self._getFeedContent(category.fetchUrl, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
 
     def _modifyItemTag(self, item_id, action, tag):
         """ wrapper around actual HTTP POST string for modify tags """

--- a/libgreader/items.py
+++ b/libgreader/items.py
@@ -17,23 +17,23 @@ class ItemsContainer(object):
         self.unread         = 0
         self.continuation   = None
 
-    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
+    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
         """
         Get content from google reader with specified parameters.
         Must be overladed in inherited clases
         """
         return None
 
-    def loadItems(self, excludeRead=False, loadLimit=20, updatedSince=None, updatedUntil=None):
+    def loadItems(self, excludeRead=False, loadLimit=20, publishedSince=None, publishedUntil=None):
         """
         Load items and call itemsLoadedDone to transform data in objects
         """
         self.clearItems()
         self.loadtLoadOk    = False
         self.lastLoadLength = 0
-        self._itemsLoadedDone(self._getContent(excludeRead, None, loadLimit, updatedSince, updatedUntil))
+        self._itemsLoadedDone(self._getContent(excludeRead, None, loadLimit, publishedSince, publishedUntil))
 
-    def loadMoreItems(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
+    def loadMoreItems(self, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
         """
         Load more items using the continuation parameters of previously loaded items.
         """
@@ -41,7 +41,7 @@ class ItemsContainer(object):
         self.lastLoadLength = 0
         if not continuation and not self.continuation:
             return
-        self._itemsLoadedDone(self._getContent(excludeRead, continuation or self.continuation, loadLimit, updatedSince, updatedUntil))
+        self._itemsLoadedDone(self._getContent(excludeRead, continuation or self.continuation, loadLimit, publishedSince, publishedUntil))
 
     def _itemsLoadedDone(self, data):
         """
@@ -129,8 +129,8 @@ class Category(ItemsContainer):
     def getFeeds(self):
         return self.feeds
 
-    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
-        return self.googleReader.getCategoryContent(self, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
+    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
+        return self.googleReader.getCategoryContent(self, excludeRead, continuation, loadLimit, publishedSince, publishedUntil)
 
     def countUnread(self):
         self.unread = sum([feed.unread for feed in self.feeds])
@@ -185,8 +185,8 @@ class BaseFeed(ItemsContainer):
     def getCategories(self):
         return self.categories
 
-    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
-        return self.googleReader.getFeedContent(self, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
+    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, publishedSince=None, publishedUntil=None):
+        return self.googleReader.getFeedContent(self, excludeRead, continuation, loadLimit, publishedSince, publishedUntil)
 
     def markItemRead(self, item, read):
         super(BaseFeed, self).markItemRead(item, read)

--- a/libgreader/items.py
+++ b/libgreader/items.py
@@ -17,23 +17,23 @@ class ItemsContainer(object):
         self.unread         = 0
         self.continuation   = None
 
-    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20):
+    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
         """
         Get content from google reader with specified parameters.
         Must be overladed in inherited clases
         """
         return None
 
-    def loadItems(self, excludeRead=False, loadLimit=20):
+    def loadItems(self, excludeRead=False, loadLimit=20, updatedSince=None, updatedUntil=None):
         """
         Load items and call itemsLoadedDone to transform data in objects
         """
         self.clearItems()
         self.loadtLoadOk    = False
         self.lastLoadLength = 0
-        self._itemsLoadedDone(self._getContent(excludeRead, None, loadLimit))
+        self._itemsLoadedDone(self._getContent(excludeRead, None, loadLimit, updatedSince, updatedUntil))
 
-    def loadMoreItems(self, excludeRead=False, continuation=None, loadLimit=20):
+    def loadMoreItems(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
         """
         Load more items using the continuation parameters of previously loaded items.
         """
@@ -41,7 +41,7 @@ class ItemsContainer(object):
         self.lastLoadLength = 0
         if not continuation and not self.continuation:
             return
-        self._itemsLoadedDone(self._getContent(excludeRead, continuation or self.continuation, loadLimit))
+        self._itemsLoadedDone(self._getContent(excludeRead, continuation or self.continuation, loadLimit, updatedSince, updatedUntil))
 
     def _itemsLoadedDone(self, data):
         """
@@ -129,8 +129,8 @@ class Category(ItemsContainer):
     def getFeeds(self):
         return self.feeds
 
-    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20):
-        return self.googleReader.getCategoryContent(self, excludeRead, continuation, loadLimit)
+    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
+        return self.googleReader.getCategoryContent(self, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
 
     def countUnread(self):
         self.unread = sum([feed.unread for feed in self.feeds])
@@ -185,8 +185,8 @@ class BaseFeed(ItemsContainer):
     def getCategories(self):
         return self.categories
 
-    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20):
-        return self.googleReader.getFeedContent(self, excludeRead, continuation, loadLimit)
+    def _getContent(self, excludeRead=False, continuation=None, loadLimit=20, updatedSince=None, updatedUntil=None):
+        return self.googleReader.getFeedContent(self, excludeRead, continuation, loadLimit, updatedSince, updatedUntil)
 
     def markItemRead(self, item, read):
         super(BaseFeed, self).markItemRead(item, read)
@@ -268,6 +268,8 @@ class Item(object):
         self.author = item.get('author', None)
         self.content = item.get('content', item.get('summary', {})).get('content', '')
         self.origin  = { 'title': '', 'url': ''}
+        self.published = item.get('published', None)
+        self.updated = item.get('updated', None)
 
         # check original url
         self.url    = None


### PR DESCRIPTION
Google Reader API support simple pagination ot and nt according to http://code.google.com/p/google-reader-api/wiki/ApiStreamContents.

Just add two options for loadItems().
Usage:
container.loadItems(until=1280149200)
container.loadItems(since=1280149200)

The modification also provide a item property: time to provide items' crawling time which since/until will check this value.
