### PR TITLE
Access token secret bugfix

### DIFF
--- a/libgreader/auth.py
+++ b/libgreader/auth.py
@@ -211,7 +211,7 @@ class OAuthMethod(AuthenticationMethod):
 
     def authFromAccessToken(self, oauth_token, oauth_token_secret):
         self.token_key         = oauth_token
-        self.token_key_secret  = oauth_token_secret
+        self.token_secret      = oauth_token_secret
         token                  = oauth.Token(oauth_token,oauth_token_secret)
         self.authorized_client = oauth.Client(self.consumer, token)
 


### PR DESCRIPTION
Token secret was being set to self.token_key_secret, so while access worked, retrieved access token credentials from OAuthMethod.getAccessToken were wrong and future OAuthMethod.authFromAccessToken attempts would fail.
