### PR TITLE
Fix import error during setup.py install

### DIFF
--- a/libgreader/__init__.py
+++ b/libgreader/__init__.py
@@ -8,7 +8,13 @@ __author__  = "Matt Behrens <askedrelic@gmail.com>"
 __version__ = "0.8.0"
 __copyright__ = "Copyright (C) 2012  Matt Behrens"
 
-from .googlereader import GoogleReader
-from .auth import AuthenticationMethod, ClientAuthMethod, OAuthMethod, OAuth2Method
-from .items import *
-from .url import ReaderUrl
+try:
+    import requests
+except ImportError:
+    # Will occur during setup.py install
+    pass
+else:
+    from .googlereader import GoogleReader
+    from .auth import AuthenticationMethod, ClientAuthMethod, OAuthMethod, OAuth2Method
+    from .items import *
+    from .url import ReaderUrl


### PR DESCRIPTION
Hey there,

Thanks for the AMAZING lib.

Unfortunately it currently can't be installed unless requests has previously been installed. 
- setup.py import libgreader (for version/author)
- libgreader import all its submodules
- some of these submodules import requests

This means requests is required to be installed prior to libgreader being installed. requests is listed as a dependency in setup.py, but it won't ever get automatically installed since setup.py will fail without it.

This commit simply wraps the submodule imports inside libgreader in a try/catch for importing requests - it'll fail during install, which is expected and fine, then succeed when the lib is actually used, and requests is installed.

Unfortunately this affects the current version uploaded to pypi - so anyone trying to install libgreader from there right now will receive this error, so it might be worthwhile pushing this change up as 0.7.1 or 0.8 asap.

Thanks again!
